### PR TITLE
The type thrd_start_t is a typedef of int(*)(void*)

### DIFF
--- a/c11threads.h
+++ b/c11threads.h
@@ -30,7 +30,7 @@ typedef pthread_cond_t cnd_t;
 typedef pthread_key_t tss_t;
 typedef pthread_once_t once_flag;
 
-typedef void (*thrd_start_t)(void*);
+typedef int (*thrd_start_t)(void*);
 typedef void (*tss_dtor_t)(void*);
 
 


### PR DESCRIPTION
The type thrd_start_t is a typedef of int(_)(void_), which differs fom the POSIX equivalent void_(_)(void*)

http://en.cppreference.com/w/c/thread/thrd_create
