### PR TITLE
detect ENOMEM in thrd_create

### DIFF
--- a/c11threads.h
+++ b/c11threads.h
@@ -58,10 +58,11 @@ enum {
 
 static inline int thrd_create(thrd_t *thr, thrd_start_t func, void *arg)
 {
-	/* XXX there's a third possible value returned according to the standard:
-	 * thrd_nomem. but it doesn't seem to correspond to any pthread_create errors.
-	 */
-	return pthread_create(thr, 0, (void*(*)(void*))func, arg) == 0 ? thrd_success : thrd_error;
+	int res = pthread_create(thr, 0, (void*(*)(void*))func, arg);
+	if (res == ENOMEM) {
+		return thrd_nomem;
+	}
+	return res == 0 ? thrd_success : thrd_error;
 }
 
 static inline void thrd_exit(int res)


### PR DESCRIPTION
Noticed the comment where you mention pthread_create doesn't seem to return something equivalent to thrd_nomem. Well, the standard error returned by any ENO*-based function for out of memory is ENOMEM and the glibc implementation at least should return that based on a quick look through its source code.