### PR TITLE
Avoid "implicit conversion loses integer precision" warning.

### DIFF
--- a/c11threads.h
+++ b/c11threads.h
@@ -78,7 +78,7 @@ static inline int thrd_join(thrd_t thr, int *res)
 		return thrd_error;
 	}
 	if(res) {
-		*res = (long)retval;
+		*res = (int)(long)retval;
 	}
 	return thrd_success;
 }


### PR DESCRIPTION
The warning I was getting before:

```
c11threads.h:81:10: warning: implicit conversion loses integer precision: 'long' to 'int' [-Wshorten-64-to-32]
```
