### PR TITLE
Do not return thrd_busy from mtx_lock()

### DIFF
--- a/c11threads.h
+++ b/c11threads.h
@@ -203,9 +203,6 @@ static C11THREADS_INLINE void mtx_destroy(mtx_t *mtx)
 static C11THREADS_INLINE int mtx_lock(mtx_t *mtx)
 {
 	int res = pthread_mutex_lock(mtx);
-	if(res == EDEADLK) {
-		return thrd_busy;
-	}
 	return res == 0 ? thrd_success : thrd_error;
 }
 


### PR DESCRIPTION
Returning `thrd_busy` from `mtx_lock()` is not standards-compliant. This behavior could cause issues with code that expects only `thrd_error` and `thrd_success` and therefore checks for `thrd_error` to detect errors.