### PR TITLE
Check if struct timespec is already defined by mingw

### DIFF
--- a/c11threads.h
+++ b/c11threads.h
@@ -394,8 +394,7 @@ struct _c11threads_win32_timespec64_t {
 #endif
 	long tv_nsec;
 };
-#ifndef _UCRT
-#ifndef _TIMESPEC_DEFINED
+#if !defined(_UCRT) && !defined(_TIMESPEC_DEFINED)
 #ifdef _USE_32BIT_TIME_T
 struct timespec {
 	long tv_sec;
@@ -407,8 +406,7 @@ struct timespec {
 	long tv_nsec;
 };
 #endif	/* !defined(_USE_32BIT_TIME_T) */
-#endif	/* !defined(_TIMESPEC_DEFINED) */
-#endif	/* !defined(_UCRT) */
+#endif	/* !defined(_UCRT) && !defined(_TIMESPEC_DEFINED) */
 
 /* Thread functions. */
 

--- a/c11threads.h
+++ b/c11threads.h
@@ -395,6 +395,7 @@ struct _c11threads_win32_timespec64_t {
 	long tv_nsec;
 };
 #ifndef _UCRT
+#ifndef _TIMESPEC_DEFINED
 #ifdef _USE_32BIT_TIME_T
 struct timespec {
 	long tv_sec;
@@ -406,6 +407,7 @@ struct timespec {
 	long tv_nsec;
 };
 #endif	/* !defined(_USE_32BIT_TIME_T) */
+#endif	/* !defined(_TIMESPEC_DEFINED) */
 #endif	/* !defined(_UCRT) */
 
 /* Thread functions. */


### PR DESCRIPTION
Hi,
thanks for the nice library!
I tested this on Debian 11 with mingw and wine.
The build failed because struct timespec was already defined in "/usr/share/mingw-w64/include/sys/timeb.h:91".
Added two lines to the header, it works now!
Hope it makes sense. :)

Best

